### PR TITLE
Resolve 'failed to load rake command' when kondate init.

### DIFF
--- a/kondate.gemspec
+++ b/kondate.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'serverspec'
   spec.add_dependency 'thor'
   spec.add_dependency 'highline'
+  spec.add_dependency "rake"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
### What happened:

```shellsession
$ cat Gemfile
# frozen_string_literal: true
source "https://rubygems.org"

gem 'kondate'
$ bundle install
Using ansi 1.5.0
Using diff-lcs 1.2.5
Using hashie 3.4.6
Using highline 1.7.8
Using schash 0.1.2
Using net-ssh 3.2.0
Using net-telnet 0.1.1
Using sfl 2.3
Using thor 0.19.1
Using multi_json 1.12.1
Using rspec-support 3.5.0
Using bundler 1.13.6
Using net-scp 1.2.1
Using rspec-core 3.5.4
Using rspec-expectations 3.5.0
Using rspec-mocks 3.5.0
Using specinfra 2.66.0
Using rspec-its 1.2.0
Using rspec 3.5.0
Using itamae 1.9.9
Using serverspec 2.37.2
Using kondate 0.2.0
Bundle complete! 1 Gemfile dependency, 22 gems now installed.
Bundled gems are installed into ./vendor/bundle.
$ bundle exec kondate init .
bundler: failed to load command: kondate (/private/tmp/foo/vendor/bundle/ruby/2.3.0/bin/kondate)
LoadError: cannot load such file -- rake
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/rake_task.rb:1:in `require'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.5.4/lib/rspec/core/rake_task.rb:1:in `<top (required)>'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/kondate-0.2.0/lib/kondate/cli.rb:4:in `require'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/kondate-0.2.0/lib/kondate/cli.rb:4:in `<top (required)>'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/kondate-0.2.0/exe/kondate:3:in `require'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/gems/kondate-0.2.0/exe/kondate:3:in `<top (required)>'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/bin/kondate:23:in `load'
  /private/tmp/foo/vendor/bundle/ruby/2.3.0/bin/kondate:23:in `<top (required)>'
```